### PR TITLE
Fix catalog dark mode

### DIFF
--- a/src/ca/cgjennings/apps/arkham/dialog/PluginManager.form
+++ b/src/ca/cgjennings/apps/arkham/dialog/PluginManager.form
@@ -236,9 +236,6 @@
             </Container>
             <Container class="javax.swing.JPanel" name="configPanel">
               <Properties>
-                <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="UIManager.getColor(Theme.PROJECT_FIND_BACKGROUND)" type="code"/>
-                </Property>
                 <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
                   <Border info="org.netbeans.modules.form.compat2.border.MatteColorBorderInfo">
                     <MatteColorBorder bottom="0" left="0" right="0" top="1">
@@ -319,9 +316,6 @@
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="enableCheck">
                   <Properties>
-                    <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="UIManager.getColor(Theme.PROJECT_FIND_FOREGROUND)" type="code"/>
-                    </Property>
                     <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                       <ResourceString bundle="resources/text/interface/eons-text.properties" key="plug-b-enabled" replaceFormat="string( &quot;{key}&quot; )"/>
                     </Property>
@@ -336,9 +330,6 @@
                       <FontInfo relative="true">
                         <Font bold="true" component="shortcutLabel" property="font" relativeSize="true" size="0"/>
                       </FontInfo>
-                    </Property>
-                    <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                      <Connection code="UIManager.getColor(Theme.PROJECT_FIND_FOREGROUND)" type="code"/>
                     </Property>
                     <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                       <ResourceString bundle="resources/text/interface/eons-text.properties" key="plug-col-key" replaceFormat="string( &quot;{key}&quot; )"/>

--- a/src/ca/cgjennings/apps/arkham/dialog/PluginManager.java
+++ b/src/ca/cgjennings/apps/arkham/dialog/PluginManager.java
@@ -248,7 +248,6 @@ public class PluginManager extends javax.swing.JDialog {
 
         compoundPluginPanel.add(pluginTitle, java.awt.BorderLayout.PAGE_START);
 
-        configPanel.setBackground(UIManager.getColor(Theme.PROJECT_FIND_BACKGROUND));
         configPanel.setBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 0, 0, java.awt.Color.gray));
 
         uninstallBtn.setFont(uninstallBtn.getFont().deriveFont(uninstallBtn.getFont().getStyle() | java.awt.Font.BOLD));
@@ -259,7 +258,6 @@ public class PluginManager extends javax.swing.JDialog {
             }
         });
 
-        enableCheck.setForeground(UIManager.getColor(Theme.PROJECT_FIND_FOREGROUND));
         enableCheck.setText(string( "plug-b-enabled" )); // NOI18N
         enableCheck.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -268,7 +266,6 @@ public class PluginManager extends javax.swing.JDialog {
         });
 
         shortcutLabel.setFont(shortcutLabel.getFont().deriveFont(shortcutLabel.getFont().getStyle() | java.awt.Font.BOLD));
-        shortcutLabel.setForeground(UIManager.getColor(Theme.PROJECT_FIND_FOREGROUND));
         shortcutLabel.setText(string( "plug-col-key" )); // NOI18N
 
         shortcutField.setText("Ctrl+Alt+Shift+Backspace");
@@ -468,6 +465,13 @@ public class PluginManager extends javax.swing.JDialog {
                 fillInTable(b, iplugin);
                 b.append("</table>");
 
+                // pending update/uninstall
+                if (iplugin.isUpdatePending()) {
+                    fillInBox(b, string("plug-l-will-update"), false);
+                } else if (iplugin.isUninstallPending()) {
+                    fillInBox(b, string("plug-l-will-uninstall"), true);
+                }
+
                 PluginBundle pb = iplugin.getBundle();
                 if (pb != null) {
                     try {
@@ -479,13 +483,6 @@ public class PluginManager extends javax.swing.JDialog {
                         }
                     } catch (IOException ioe) {
                     }
-                }
-
-                // pending update/uninstall
-                if (iplugin.isUpdatePending()) {
-                    fillInBox(b, string("plug-l-will-update"), false);
-                } else if (iplugin.isUninstallPending()) {
-                    fillInBox(b, string("plug-l-will-uninstall"), true);
                 }
             }
 
@@ -540,10 +537,9 @@ public class PluginManager extends javax.swing.JDialog {
     }
 
     private void fillInBox(StringBuilder b, String text, boolean warn) {
-        b.append("<p align='center'><table border=0 bgcolor=#")
-                .append(warn ? "efe7b1" : "b1b1ef")
-                .append(" width=80% cellspacing=0 cellpadding=8><tr><td>");
-        b.append(text).append("</table>");
+        b.append("<p align='center' style='padding: 4px; border: 2px #")
+            .append(warn ? "ffa000" : "1565c0").append(" solid'>")
+            .append(text).append("</p>");
     }
 
 	private void openPluginFolderBtnActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_openPluginFolderBtnActionPerformed

--- a/src/ca/cgjennings/apps/arkham/plugins/InstallationNotesViewer.form
+++ b/src/ca/cgjennings/apps/arkham/plugins/InstallationNotesViewer.form
@@ -65,12 +65,15 @@
         <Component class="javax.swing.JEditorPane" name="view">
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
-            <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-              <Color blue="ff" green="fe" red="fe" type="rgb"/>
+            <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="UIManager.getColor(Theme.PLUGIN_README_BACKGROUND)" type="code"/>
             </Property>
             <Property name="contentType" type="java.lang.String" value="text/html" noResource="true"/>
             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
               <Font name="SansSerif" size="12" style="0"/>
+            </Property>
+            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
             </Property>
           </Properties>
           <AuxValues>

--- a/src/ca/cgjennings/apps/arkham/plugins/InstallationNotesViewer.java
+++ b/src/ca/cgjennings/apps/arkham/plugins/InstallationNotesViewer.java
@@ -4,10 +4,12 @@ import ca.cgjennings.apps.arkham.StrangeEons;
 import ca.cgjennings.apps.arkham.dialog.ErrorDialog;
 import ca.cgjennings.platform.DesktopIntegration;
 import ca.cgjennings.ui.EditorPane;
+import ca.cgjennings.ui.theme.Theme;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.logging.Level;
+import javax.swing.UIManager;
 import javax.swing.event.HyperlinkEvent;
 import static resources.Language.string;
 
@@ -85,9 +87,10 @@ final class InstallationNotesViewer extends javax.swing.JDialog {
         jScrollPane1.setBorder(javax.swing.BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.gray));
 
         view.setEditable(false);
-        view.setBackground(new java.awt.Color(254, 254, 255));
+        view.setBackground(UIManager.getColor(Theme.PLUGIN_README_BACKGROUND));
         view.setContentType("text/html"); // NOI18N
         view.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
+        view.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         jScrollPane1.setViewportView(view);
 
         closeBtn.setText(string("close")); // NOI18N

--- a/src/ca/cgjennings/apps/arkham/plugins/catalog/CatalogDialog.form
+++ b/src/ca/cgjennings/apps/arkham/plugins/catalog/CatalogDialog.form
@@ -434,8 +434,8 @@
                   <SubComponents>
                     <Container class="javax.swing.JPanel" name="infoPanel">
                       <Properties>
-                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                          <Color blue="ff" green="ff" id="white" palette="1" red="ff" type="palette"/>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                          <Connection code="UIManager.getColor(Theme.PLUGIN_README_BACKGROUND)" type="code"/>
                         </Property>
                         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
                           <Border info="org.netbeans.modules.form.compat2.border.EmptyBorderInfo">
@@ -529,13 +529,16 @@
                       <SubComponents>
                         <Component class="javax.swing.JLabel" name="nameLabel">
                           <Properties>
-                            <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                              <Color blue="c0" green="c0" id="lightGray" palette="1" red="c0" type="palette"/>
+                            <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.HEAD_BANNER_BACKGROUND)" type="code"/>
                             </Property>
                             <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
                               <FontInfo relative="true">
                                 <Font bold="true" component="nameLabel" property="font" relativeSize="true" size="2"/>
                               </FontInfo>
+                            </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.HEAD_BANNER_FOREGROUND)" type="code"/>
                             </Property>
                             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
                               <Border info="org.netbeans.modules.form.compat2.border.CompoundBorderInfo">
@@ -561,6 +564,9 @@
                                 <Font bold="true" component="jLabel3" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
                             </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
+                            </Property>
                             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                               <ResourceString bundle="resources/text/interface/eons-text.properties" key="cat-ver" replaceFormat="string( &quot;{key}&quot; )"/>
                             </Property>
@@ -573,6 +579,9 @@
                                 <Font component="verLabel" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
                             </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
+                            </Property>
                             <Property name="text" type="java.lang.String" value="*"/>
                           </Properties>
                         </Component>
@@ -582,6 +591,9 @@
                               <FontInfo relative="true">
                                 <Font bold="true" component="jLabel1" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
+                            </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
                             </Property>
                             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                               <ResourceString bundle="resources/text/interface/eons-text.properties" key="cat-home" replaceFormat="string( &quot;{key}&quot; )"/>
@@ -602,7 +614,7 @@
                           <Properties>
                             <Property name="editable" type="boolean" value="false"/>
                             <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                              <Connection code=" Color.WHITE " type="code"/>
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_BACKGROUND)" type="code"/>
                             </Property>
                             <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
                               <Border info="org.netbeans.modules.form.compat2.border.CompoundBorderInfo">
@@ -623,7 +635,7 @@
                               <Font name="SansSerif" size="12" style="0"/>
                             </Property>
                             <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                              <Connection code=" Color.BLACK " type="code"/>
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
                             </Property>
                             <Property name="componentPopupMenu" type="javax.swing.JPopupMenu" editor="org.netbeans.modules.form.ComponentChooserEditor">
                               <ComponentRef name="descriptionPopup"/>
@@ -635,6 +647,9 @@
                         </Component>
                         <Component class="javax.swing.JLabel" name="installStateLabel">
                           <Properties>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
+                            </Property>
                             <Property name="text" type="java.lang.String" value="state"/>
                           </Properties>
                         </Component>
@@ -644,6 +659,9 @@
                               <FontInfo relative="true">
                                 <Font bold="true" component="jLabel4" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
+                            </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
                             </Property>
                             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                               <ResourceString bundle="resources/text/interface/eons-text.properties" key="cat-size" replaceFormat="string( &quot;{key}&quot; )"/>
@@ -657,6 +675,9 @@
                                 <Font component="sizeLabel" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
                             </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
+                            </Property>
                             <Property name="text" type="java.lang.String" value="*"/>
                           </Properties>
                         </Component>
@@ -666,6 +687,9 @@
                               <FontInfo relative="true">
                                 <Font bold="true" component="jLabel6" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
+                            </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
                             </Property>
                             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                               <ResourceString bundle="resources/text/interface/eons-text.properties" key="cat-credit" replaceFormat="string( &quot;{key}&quot; )"/>
@@ -679,6 +703,9 @@
                                 <Font component="creditsLabel" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
                             </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
+                            </Property>
                             <Property name="text" type="java.lang.String" value="*"/>
                           </Properties>
                         </Component>
@@ -688,6 +715,9 @@
                               <FontInfo relative="true">
                                 <Font bold="true" component="coreLabel" property="font" relativeSize="true" size="-1"/>
                               </FontInfo>
+                            </Property>
+                            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+                              <Connection code="UIManager.getColor(Theme.PLUGIN_README_FOREGROUND)" type="code"/>
                             </Property>
                             <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                               <ResourceString bundle="resources/text/interface/eons-text.properties" key="cat-l-core" replaceFormat="string( &quot;{key}&quot; )"/>
@@ -876,6 +906,12 @@
     </Component>
     <Component class="ca.cgjennings.ui.JWarningLabel" name="restartWarnLabel">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="UIManager.getColor(Theme.MESSAGE_BACKGROUND)" type="code"/>
+        </Property>
+        <Property name="foreground" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="UIManager.getColor(Theme.MESSAGE_FOREGROUND)" type="code"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="resources/text/interface/eons-text.properties" key="cat-restart-required" replaceFormat="string(&quot;{key}&quot;)"/>
         </Property>

--- a/src/ca/cgjennings/apps/arkham/plugins/catalog/CatalogDialog.java
+++ b/src/ca/cgjennings/apps/arkham/plugins/catalog/CatalogDialog.java
@@ -15,6 +15,7 @@ import ca.cgjennings.ui.JLabelledField;
 import ca.cgjennings.ui.dnd.ScrapBook;
 import ca.cgjennings.ui.table.BooleanRenderer;
 import ca.cgjennings.ui.table.IconRenderer;
+import ca.cgjennings.ui.theme.Theme;
 import gamedata.Game;
 import java.awt.CardLayout;
 import java.awt.Color;
@@ -850,7 +851,7 @@ public final class CatalogDialog extends javax.swing.JDialog implements Agnostic
                     e.printStackTrace();
                 }
                 listingText.flush();
-                descText += "<p style='background-color: #f7f7ff; font-family: Consolas, Andale Mono, Monospaced'>"
+                descText += "<p style='font-family: Consolas, Andale Mono, Monospaced'>"
                         + listingText.toString().replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>")
                         + "</p>";
             }
@@ -1079,49 +1080,59 @@ public final class CatalogDialog extends javax.swing.JDialog implements Agnostic
 
         infoScroll.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
 
-        infoPanel.setBackground(java.awt.Color.white);
+        infoPanel.setBackground(UIManager.getColor(Theme.PLUGIN_README_BACKGROUND));
         infoPanel.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
 
-        nameLabel.setBackground(java.awt.Color.lightGray);
+        nameLabel.setBackground(UIManager.getColor(Theme.HEAD_BANNER_BACKGROUND));
         nameLabel.setFont(nameLabel.getFont().deriveFont(nameLabel.getFont().getStyle() | java.awt.Font.BOLD, nameLabel.getFont().getSize()+2));
+        nameLabel.setForeground(UIManager.getColor(Theme.HEAD_BANNER_FOREGROUND));
         nameLabel.setBorder(javax.swing.BorderFactory.createCompoundBorder(javax.swing.BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.darkGray), javax.swing.BorderFactory.createEmptyBorder(2, 8, 4, 8)));
         nameLabel.setOpaque(true);
 
         jLabel3.setFont(jLabel3.getFont().deriveFont(jLabel3.getFont().getStyle() | java.awt.Font.BOLD, jLabel3.getFont().getSize()-1));
+        jLabel3.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         jLabel3.setText(string( "cat-ver" )); // NOI18N
 
         verLabel.setFont(verLabel.getFont().deriveFont(verLabel.getFont().getSize()-1f));
+        verLabel.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         verLabel.setText("*");
 
         jLabel1.setFont(jLabel1.getFont().deriveFont(jLabel1.getFont().getStyle() | java.awt.Font.BOLD, jLabel1.getFont().getSize()-1));
+        jLabel1.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         jLabel1.setText(string( "cat-home" )); // NOI18N
 
         pageLabel.setText("*");
         pageLabel.setFont(pageLabel.getFont().deriveFont(pageLabel.getFont().getSize()-1f));
 
         descPane.setEditable(false);
-        descPane.setBackground( Color.WHITE );
+        descPane.setBackground(UIManager.getColor(Theme.PLUGIN_README_BACKGROUND));
         descPane.setBorder(javax.swing.BorderFactory.createCompoundBorder(javax.swing.BorderFactory.createMatteBorder(1, 0, 0, 0, java.awt.Color.darkGray), javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8)));
         descPane.setContentType("text/html"); // NOI18N
         descPane.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
-        descPane.setForeground( Color.BLACK );
+        descPane.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         descPane.setComponentPopupMenu(descriptionPopup);
 
+        installStateLabel.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         installStateLabel.setText("state");
 
         jLabel4.setFont(jLabel4.getFont().deriveFont(jLabel4.getFont().getStyle() | java.awt.Font.BOLD, jLabel4.getFont().getSize()-1));
+        jLabel4.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         jLabel4.setText(string( "cat-size" )); // NOI18N
 
         sizeLabel.setFont(sizeLabel.getFont().deriveFont(sizeLabel.getFont().getSize()-1f));
+        sizeLabel.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         sizeLabel.setText("*");
 
         jLabel6.setFont(jLabel6.getFont().deriveFont(jLabel6.getFont().getStyle() | java.awt.Font.BOLD, jLabel6.getFont().getSize()-1));
+        jLabel6.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         jLabel6.setText(string( "cat-credit" )); // NOI18N
 
         creditsLabel.setFont(creditsLabel.getFont().deriveFont(creditsLabel.getFont().getSize()-1f));
+        creditsLabel.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         creditsLabel.setText("*");
 
         coreLabel.setFont(coreLabel.getFont().deriveFont(coreLabel.getFont().getStyle() | java.awt.Font.BOLD, coreLabel.getFont().getSize()-1));
+        coreLabel.setForeground(UIManager.getColor(Theme.PLUGIN_README_FOREGROUND));
         coreLabel.setText(string( "cat-l-core" )); // NOI18N
 
         javax.swing.GroupLayout infoPanelLayout = new javax.swing.GroupLayout(infoPanel);
@@ -1299,6 +1310,8 @@ public final class CatalogDialog extends javax.swing.JDialog implements Agnostic
             }
         });
 
+        restartWarnLabel.setBackground(UIManager.getColor(Theme.MESSAGE_BACKGROUND));
+        restartWarnLabel.setForeground(UIManager.getColor(Theme.MESSAGE_FOREGROUND));
         restartWarnLabel.setText(string("cat-restart-required")); // NOI18N
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());

--- a/src/ca/cgjennings/ui/theme/Theme.java
+++ b/src/ca/cgjennings/ui/theme/Theme.java
@@ -301,7 +301,7 @@ public abstract class Theme {
      * tabs should switch their orientation. Set if tabs look wrong for a
      * given L&F. 
      */
-    public static final String ALTERNATE_DOCUMENT_TAB_ORIENTATION = "se-alt-doc-tab-dir";
+    public static final String ALTERNATE_DOCUMENT_TAB_ORIENTATION = "eons-alt-doc-tab-dir";
     /**
      * A UI key that contains the {@code Border} used for headings and
      * subheadings. If {@code null}, a default algorithm is used to create
@@ -311,22 +311,22 @@ public abstract class Theme {
      *
      * @see JHeading
      */
-    public static final String HEADING_BORDER = "se-heading-border";
+    public static final String HEADING_BORDER = "eons-heading-border";
     /**
      * A UI key that contains the {@code Color} used for the background of
      * the editor tabs.
      */
-    public static final String EDITOR_TAB_BACKGROUND = "se-editor-tab-background";
+    public static final String EDITOR_TAB_BACKGROUND = "eons-editor-tab-background";
     /**
      * A UI key that contains the {@code Color} used for the background of
      * sidepanel title bars, like at the top of project views.
      */
-    public static final String SIDEPANEL_TITLE_BACKGROUND = "se-title-background";
+    public static final String SIDEPANEL_TITLE_BACKGROUND = "eons-title-background";
     /**
      * A UI key that contains the {@code Color} used for the foreground of
      * sidepanel title bars, like at the top of project views.
      */
-    public static final String SIDEPANEL_TITLE_FOREGROUND = "se-title-foreground";
+    public static final String SIDEPANEL_TITLE_FOREGROUND = "eons-title-foreground";
     /**
      * A UI key that contains the {@code Color} used for the border drawn
      * around fields that accept a file drop when files are dragged over them.
@@ -335,49 +335,49 @@ public abstract class Theme {
     /**
      * UI key for context bar background colour.
      */
-    public static final String CONTEXT_BAR_BACKGROUND = "se-cb-bg";
+    public static final String CONTEXT_BAR_BACKGROUND = "eons-cb-bg";
     /**
      * UI key for context bar foreground colour.
      */
-    public static final String CONTEXT_BAR_FOREGROUND = "se-cb-fg";
+    public static final String CONTEXT_BAR_FOREGROUND = "eons-cb-fg";
     /**
      * UI key for context bar button background colour.
      */
-    public static final String CONTEXT_BAR_BUTTON_BACKGROUND = "se-cb-btn-bg";
+    public static final String CONTEXT_BAR_BUTTON_BACKGROUND = "eons-cb-btn-bg";
     /**
      * UI key for context bar button background colour when under pointer.
      */
-    public static final String CONTEXT_BAR_BUTTON_ROLLOVER_BACKGROUND = "se-cb-btn-bghi";
+    public static final String CONTEXT_BAR_BUTTON_ROLLOVER_BACKGROUND = "eons-cb-btn-bghi";
     /**
      * UI key for context bar button outline colour when under pointer.
      */
-    public static final String CONTEXT_BAR_BUTTON_ROLLOVER_OUTLINE_FOREGROUND = "se-cb-brdr-fg";
+    public static final String CONTEXT_BAR_BUTTON_ROLLOVER_OUTLINE_FOREGROUND = "eons-cb-brdr-fg";
     /**
      * UI key for context bar button outline colour when held down.
      */
-    public static final String CONTEXT_BAR_BUTTON_ARMED_OUTLINE_FOREGROUND = "se-cb-brdr-fghi";
+    public static final String CONTEXT_BAR_BUTTON_ARMED_OUTLINE_FOREGROUND = "eons-cb-brdr-fghi";
     /**
      * A UI key for an adjustment applied to the margin of cycle buttons to move
      * the cycle icon close to the button edge.
      */
-    public static final String CYCLE_BUTTON_ICON_MARGIN_ADJUSTMENT = "se-cycle-margin";
+    public static final String CYCLE_BUTTON_ICON_MARGIN_ADJUSTMENT = "eons-cycle-margin";
     /**
      * UI key for console background colour; used if painter is
      * {@code null}.
      */
-    public static final String CONSOLE_BACKROUND = "se-conbg";
+    public static final String CONSOLE_BACKROUND = "eons-conbg";
     /**
      * UI key for console background colour.
      */
-    public static final String CONSOLE_BACKGROUND_PAINTER = "se-conp";
+    public static final String CONSOLE_BACKGROUND_PAINTER = "eons-conp";
     /**
      * UI key for console output text colour.
      */
-    public static final String CONSOLE_OUTPUT = "se-conout";
+    public static final String CONSOLE_OUTPUT = "eons-conout";
     /**
      * UI key for console error text colour.
      */
-    public static final String CONSOLE_ERROR = "se-conerr";
+    public static final String CONSOLE_ERROR = "eons-conerr";
     /**
      * UI key for console text selection background colour.
      */
@@ -393,15 +393,15 @@ public abstract class Theme {
     /**
      * UI key for text notes panels (e.g., project notes) background colour.
      */
-    public static final String NOTES_BACKGROUND = "se-notes-bg";
+    public static final String NOTES_BACKGROUND = "eons-notes-bg";
     /**
      * UI key for text notes panels (e.g., project notes) foreground colour.
      */
-    public static final String NOTES_FOREGROUND = "se-notes-fg";
+    public static final String NOTES_FOREGROUND = "eons-notes-fg";
     /**
      * UI key for the foreground colour of {@link JLinkLabel}s.
      */
-    public static final String LINK_LABEL_FOREGROUND = "se-link-label-fg";
+    public static final String LINK_LABEL_FOREGROUND = "eons-link-label-fg";
     /**
      * Exterior border colour of mesage pop-ups.
      */
@@ -433,51 +433,56 @@ public abstract class Theme {
     /**
      * UI key for project search field background colour.
      */
-    public static final String PROJECT_FIND_BACKGROUND = "se-projfind-bg";
+    public static final String PROJECT_FIND_BACKGROUND = "eons-projfind-bg";
     /**
      * UI key for project search field foreground colour.
      */
-    public static final String PROJECT_FIND_FOREGROUND = "se-projfind-fg";
+    public static final String PROJECT_FIND_FOREGROUND = "eons-projfind-fg";
+    /**
+     * UI key for plug-in installation notes and catalog info background colour.
+     */
+    public static final String PLUGIN_README_BACKGROUND = "eons-readme-bg";
+    /**
+     * UI key for plug-in installation notes and catalog info foreground colour.
+     */
+    public static final String PLUGIN_README_FOREGROUND = "eons-readme-fg";
     /**
      * UI key for the project area properties/notes tabs background color.
      */
-    public static final String PROJECT_NOTES_TAB_BACKGROUND = "se-projnotestab-bg";
-
+    public static final String PROJECT_NOTES_TAB_BACKGROUND = "eons-projnotestab-bg";
     /**
      * UI key for the background colour used for project view headers
      * (Project Files, Add New Task..., Properties/Notes, etc.)
      */
-    public static final String PROJECT_HEADER_BACKGROUND = "se-projhead-bg";
-
+    public static final String PROJECT_HEADER_BACKGROUND = "eons-projhead-bg";
     /**
      * UI key for the background colour used for project view headers
      * (Project Files, Add New Task..., Properties/Notes, etc.)
      */
-    public static final String PROJECT_HEADER_FOREGROUND = "se-projhead-fg";
-
+    public static final String PROJECT_HEADER_FOREGROUND = "eons-projhead-fg";
     /**
      * UI key for project search field background colour.
      */
-    public static final String PREFS_BACKGROUND = "se-pref-bg";
+    public static final String PREFS_BACKGROUND = "eons-pref-bg";
     /**
      * UI key for project search field foreground colour.
      */
-    public static final String PREFS_FOREGROUND = "se-pref-fg";
+    public static final String PREFS_FOREGROUND = "eons-pref-fg";
     /**
      * UI key for project search field foreground colour.
      */
-    public static final String PREFS_HEADING = "se-pref-head";
+    public static final String PREFS_HEADING = "eons-pref-head";
     /**
      * UI key for the "head banner" foreground colour. This is a rectangular
      * banner with higher contrast than a standard label-on-panel.
      * The most prominent example is the {@link MultiCloseDialog}.
      */
-    public static final String HEAD_BANNER_FOREGROUND = "se-headbanner-fg";
+    public static final String HEAD_BANNER_FOREGROUND = "eons-headbanner-fg";
     /**
      * UI key for the "head banner" backround colour. This is a rectangular
      * banner with higher contrast than a standard label-on-panel.
      */
-    public static final String HEAD_BANNER_BACKGROUND = "se-headbanner-bg";
+    public static final String HEAD_BANNER_BACKGROUND = "eons-headbanner-bg";
 
     /**
      * An image filter used to create a disabled icon from a regular icon when

--- a/src/ca/cgjennings/ui/theme/ThemeInstaller.java
+++ b/src/ca/cgjennings/ui/theme/ThemeInstaller.java
@@ -259,11 +259,14 @@ public class ThemeInstaller {
         UIManager.put(Theme.PROJECT_HEADER_FOREGROUND, Color.WHITE);
         UIManager.put(Theme.PROJECT_FIND_BACKGROUND, dark? Color.BLACK : Color.WHITE);
         UIManager.put(Theme.PROJECT_FIND_FOREGROUND, dark? Color.WHITE : Color.BLACK);
-        UIManager.put(Theme.PREFS_BACKGROUND, dark ? new Color(0x111111) : Color.WHITE);
+        UIManager.put(Theme.PREFS_BACKGROUND, dark ? new Color(0x202020) : Color.WHITE);
         UIManager.put(Theme.PREFS_FOREGROUND, dark ? Color.WHITE : Color.BLACK);
         UIManager.put(Theme.PREFS_HEADING, new Color(135, 103, 5));
         UIManager.put(Theme.HEAD_BANNER_BACKGROUND, UIManager.get(Theme.PREFS_BACKGROUND));
         UIManager.put(Theme.HEAD_BANNER_FOREGROUND, UIManager.get(Theme.PREFS_FOREGROUND));
+
+        UIManager.put(Theme.PLUGIN_README_BACKGROUND, UIManager.getColor(Theme.PREFS_BACKGROUND));
+        UIManager.put(Theme.PLUGIN_README_FOREGROUND, UIManager.getColor(Theme.PREFS_FOREGROUND));
 
         UIDefaults ui = UIManager.getDefaults();
         ui.put(Theme.EDITOR_TAB_BACKGROUND, new Color(0x73_96ab));

--- a/src/ca/cgjennings/ui/theme/UltharTheme.java
+++ b/src/ca/cgjennings/ui/theme/UltharTheme.java
@@ -26,7 +26,6 @@ public class UltharTheme extends Theme {
     @Override
     public void modifyManagerDefaults(UIDefaults defaults) {
         final boolean dark = isDark();
-        final Color DEEP_GREY = new Color(0x333333);
         UIManager.put( "Button.arc", 999 );
         UIManager.put( "ScrollBar.width", 12 );
         UIManager.put( "ScrollBar.thumbArc", 999 );
@@ -37,9 +36,14 @@ public class UltharTheme extends Theme {
         UIManager.put(NOTES_BACKGROUND, null);
         UIManager.put(EDITOR_TAB_BACKGROUND, null);
         if(dark) {
-            UIManager.put(PROJECT_HEADER_BACKGROUND, DEEP_GREY);
-            UIManager.put(PROJECT_FIND_BACKGROUND, null);
+            final Color DEEPER_GREY = new Color(0x27292a);
+            final Color BRIGHT_GREY = new Color(0xa0aba6);
+            UIManager.put(PROJECT_HEADER_BACKGROUND, DEEPER_GREY);
+            UIManager.put(PROJECT_FIND_BACKGROUND, DEEPER_GREY);
+            UIManager.put(PLUGIN_README_BACKGROUND, DEEPER_GREY);
+            UIManager.put(PLUGIN_README_FOREGROUND, BRIGHT_GREY);
         } else {
+            final Color DEEP_GREY = new Color(0x3c3f41);
             final Color DIVIDER = new Color(0xe7e7e7);
             UIManager.put("SplitPane.background", DIVIDER);
             UIManager.put(PROJECT_HEADER_BACKGROUND, DIVIDER);


### PR DESCRIPTION
During the plug-in installation and management flows, the information areas, install notes, and "will require relaunch" box are not themeable and do not have dark mode defaults.