### PR TITLE
give conversion methods default implementation in GameComponent

### DIFF
--- a/src/ca/cgjennings/apps/arkham/component/AbstractGameComponent.java
+++ b/src/ca/cgjennings/apps/arkham/component/AbstractGameComponent.java
@@ -485,17 +485,4 @@ public abstract class AbstractGameComponent implements Serializable, Cloneable, 
         comments = (String) in.readObject();
         privateSettings = (Settings) in.readObject();
     }
-
-    @Override
-    public UpgradeConversionTrigger createUpgradeConversionTrigger() {
-        return null;
-    }
-
-    @Override
-    public void convertFrom(ConversionSession session) {
-    }
-
-    @Override
-    public void convertTo(ConversionSession session) {
-    }
 }

--- a/src/ca/cgjennings/apps/arkham/component/GameComponent.java
+++ b/src/ca/cgjennings/apps/arkham/component/GameComponent.java
@@ -259,7 +259,9 @@ public interface GameComponent extends Serializable, Cloneable {
      * @see ConversionSession
      * @return a conversion context if the upgrade requires a conversion
      */
-    public UpgradeConversionTrigger createUpgradeConversionTrigger();
+    default UpgradeConversionTrigger createUpgradeConversionTrigger() {
+        return null;
+    }
 
     /**
      * Called on a component that is being converted into another component
@@ -272,7 +274,8 @@ public interface GameComponent extends Serializable, Cloneable {
      * @param target the new component that will replace this one
      * @param context the conversion context
      */
-    public void convertFrom(ConversionSession session);
+    default void convertFrom(ConversionSession session) {
+    }
 
     /**
      * Called on the replacement component when converting a component to
@@ -285,5 +288,6 @@ public interface GameComponent extends Serializable, Cloneable {
      * @param source the old component that will be replaced
      * @param context the conversion context
      */
-    public void convertTo(ConversionSession session);
+    default void convertTo(ConversionSession session) {
+    }
 }


### PR DESCRIPTION
Some very old compiled game component types are not derived from `AbstractGameComponent` and therefore fail to  instantiate without the new conversion-related methods. Instead of requiring a plug-in update (which would be tricky since old versions without the conversion code could not use the new plug-in and vice-versa), these methods are given a default implementation in the `GameComponent` interface. The existing default implementation in `AbstractGameComponent` is deleted, since it is identical.