### PR TITLE
Fix parsed resource editors should ignore colon

### DIFF
--- a/src/ca/cgjennings/apps/arkham/editors/CodeEditor.java
+++ b/src/ca/cgjennings/apps/arkham/editors/CodeEditor.java
@@ -37,6 +37,7 @@ import ca.cgjennings.ui.textedit.tokenizers.JavaScriptTokenizer;
 import ca.cgjennings.ui.textedit.tokenizers.JavaTokenizer;
 import ca.cgjennings.ui.textedit.tokenizers.PlainTextTokenizer;
 import ca.cgjennings.ui.textedit.tokenizers.PropertyTokenizer;
+import ca.cgjennings.ui.textedit.tokenizers.ResourceFileTokenizer;
 import ca.cgjennings.ui.theme.Theme;
 import java.awt.Color;
 import java.awt.Component;
@@ -371,9 +372,9 @@ public class CodeEditor extends AbstractSupportEditor {
         JAVA("java", "prj-prop-java", ProjectUtilities.ENC_SCRIPT, JavaTokenizer.class, null, MetadataSource.ICON_JAVA, true),
         PROPERTIES("properties", "prj-prop-props", ProjectUtilities.ENC_UI_PROPERTIES, PropertyTokenizer.class, PropertyNavigator.class, MetadataSource.ICON_PROPERTIES, true),
         SETTINGS("settings", "prj-prop-txt", ProjectUtilities.ENC_SETTINGS, PropertyTokenizer.class, PropertyNavigator.class, MetadataSource.ICON_SETTINGS, true),
-        CLASS_MAP("classmap", "prj-prop-class-map", ProjectUtilities.ENC_SETTINGS, PropertyTokenizer.class, PropertyNavigator.class, MetadataSource.ICON_CLASS_MAP, true),
-        SILHOUETTES("silhouettes", "prj-prop-sil", ProjectUtilities.ENC_SETTINGS, PropertyTokenizer.class, PropertyNavigator.class, MetadataSource.ICON_SILHOUETTES, true),
-        TILES("tiles", "prj-prop-tiles", ProjectUtilities.ENC_SETTINGS, PropertyTokenizer.class, TileSetNavigator.class, MetadataSource.ICON_TILE_SET, true),
+        CLASS_MAP("classmap", "prj-prop-class-map", ProjectUtilities.ENC_SETTINGS, ResourceFileTokenizer.class, ResourceFileNavigator.class, MetadataSource.ICON_CLASS_MAP, true),
+        SILHOUETTES("silhouettes", "prj-prop-sil", ProjectUtilities.ENC_SETTINGS, ResourceFileTokenizer.class, ResourceFileNavigator.class, MetadataSource.ICON_SILHOUETTES, true),
+        TILES("tiles", "prj-prop-tiles", ProjectUtilities.ENC_SETTINGS, ResourceFileTokenizer.class, TileSetNavigator.class, MetadataSource.ICON_TILE_SET, true),
         HTML("html", "pa-new-html", null, HTMLTokenizer.class, HTMLNavigator.class, MetadataSource.ICON_HTML, false),
         CSS("css", "prj-prop-css", null, CSSTokenizer.class, null, MetadataSource.ICON_STYLE_SHEET, false),
         PLAIN_UTF8("utf8", "prj-prop-utf8", null, null, null, MetadataSource.ICON_FILE, false),

--- a/src/ca/cgjennings/apps/arkham/editors/PropertyNavigator.java
+++ b/src/ca/cgjennings/apps/arkham/editors/PropertyNavigator.java
@@ -12,6 +12,15 @@ import java.util.regex.Pattern;
  * @since 3.0
  */
 public class PropertyNavigator implements Navigator {
+    private final boolean ignoreColon;
+
+    public PropertyNavigator() {
+        ignoreColon = false;
+    }
+
+    public PropertyNavigator(boolean ignoreColons) {
+        ignoreColon = ignoreColons;
+    }
 
     @Override
     public void install(CodeEditor editor) {
@@ -39,7 +48,7 @@ public class PropertyNavigator implements Navigator {
                     continue;
                 }
                 int split = line.indexOf('=');
-                int colon = line.indexOf(':');
+                int colon = ignoreColon ? -1 : line.indexOf(':');
                 if (split < 0 || (colon >= 0 && colon < split)) {
                     split = colon;
                 }

--- a/src/ca/cgjennings/apps/arkham/editors/ResourceFileNavigator.java
+++ b/src/ca/cgjennings/apps/arkham/editors/ResourceFileNavigator.java
@@ -1,0 +1,14 @@
+package ca.cgjennings.apps.arkham.editors;
+
+/**
+ * Navigator for editing files that are parsed by using a {@link ResourceParser}
+ * to read properties.
+ *
+ * @author Chris Jennings <https://cgjennings.ca/contact>
+ * @since 3.3
+ */
+public class ResourceFileNavigator extends PropertyNavigator {
+    public ResourceFileNavigator() {
+        super(true);
+    }
+}

--- a/src/ca/cgjennings/io/EscapedLineReader.java
+++ b/src/ca/cgjennings/io/EscapedLineReader.java
@@ -9,6 +9,8 @@ import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * A buffered input stream reader that transparently converts escaped characters
@@ -68,13 +70,13 @@ public class EscapedLineReader extends LineNumberReader {
 
     /**
      * Creates a line reader for the specified input stream using a default
-     * buffer size.The encoding is assumed to be ISO-8859-15.
+     * buffer size. The encoding is assumed to be ISO-8859-15.
      *
      * @param in the input stream to read from
-     * @throws java.io.UnsupportedEncodingException
      */
-    public EscapedLineReader(InputStream in) throws UnsupportedEncodingException {
-        super(new InputStreamReader(in, RESOURCE_ENCODING));
+    public EscapedLineReader(InputStream in) {
+        super(new InputStreamReader(in, RESOURCE_CHARSET));
+        setLineNumber(1);
     }
 
     /**
@@ -87,6 +89,7 @@ public class EscapedLineReader extends LineNumberReader {
      */
     public EscapedLineReader(InputStream in, String charset) throws UnsupportedEncodingException {
         super(new InputStreamReader(in, charset));
+        setLineNumber(1);
     }
 
     /**
@@ -98,6 +101,7 @@ public class EscapedLineReader extends LineNumberReader {
      */
     public EscapedLineReader(InputStream in, Charset charset) {
         super(new InputStreamReader(in, charset));
+        setLineNumber(1);
     }
 
     /**
@@ -109,6 +113,7 @@ public class EscapedLineReader extends LineNumberReader {
      */
     public EscapedLineReader(URL url) throws IOException {
         super(new InputStreamReader(url.openStream(), RESOURCE_ENCODING));
+        setLineNumber(1);
     }
 
     /**
@@ -121,6 +126,7 @@ public class EscapedLineReader extends LineNumberReader {
      */
     public EscapedLineReader(URL url, String charset) throws IOException {
         super(new InputStreamReader(url.openStream(), charset));
+        setLineNumber(1);
     }
 
     /**
@@ -131,20 +137,36 @@ public class EscapedLineReader extends LineNumberReader {
      * @throws java.io.IOException
      */
     public EscapedLineReader(File f) throws IOException {
-        this(f.toURI().toURL());
+        this(f, RESOURCE_ENCODING);
     }
 
+    /**
+     * Creates a line reader that reads from the specified file, using a default
+     * buffer size and the specified encoding.
+     *
+     * @param f the file to read from
+     * @param charset the name of the character set to use, such as "UTF-8"
+     * @throws java.io.IOException
+     */
+    public EscapedLineReader(File f, String charset) throws IOException {
+        this(f.toURI().toURL(), charset);
+    }
+
+
     static final String RESOURCE_ENCODING = "iso-8859-15";
+    static final Charset RESOURCE_CHARSET = Charset.forName(RESOURCE_ENCODING);
 
     /**
      * Returns the next logical line from the stream, or null if the end of the
      * stream has been reached.The next logical line may consist of several
      * "natural" lines in the original file.Natural lines are concatenated into
      * a single logical line when a backslash character occurs immediately
-     * before the line separator between them. For example:      {@code 
+     * before the line separator between them. For example:
+     *
+     * <pre>
      * These two natural lines will \
      * form a single logical line.
-     * }
+     * </pre>
      *
      * <p>
      * A backslash is also used to introduce escape sequences. The sequences \n,
@@ -202,7 +224,7 @@ public class EscapedLineReader extends LineNumberReader {
      * @throws IOException
      */
     public String[] readProperty() throws IOException {
-        return readProperty(true);
+        return readProperty(true, null);
     }
 
     /**
@@ -220,6 +242,10 @@ public class EscapedLineReader extends LineNumberReader {
      * @throws IOException
      */
     public String[] readProperty(boolean skipEmptyLines) throws IOException {
+        return readProperty(skipEmptyLines, null);
+    }
+    
+    private String[] readProperty(boolean skipEmptyLines, String[] entry) throws IOException {
         String line = skipEmptyLines ? readNonemptyLineUnescaped() : readLineUnescaped();
         if (line == null) {
             return null;
@@ -238,9 +264,35 @@ public class EscapedLineReader extends LineNumberReader {
             }
             ++div;
         }
-        String key = unescapeLine(line.substring(0, div).trim());
-        String value = unescapeLine(line.substring(div + 1));
-        return new String[]{key.trim(), value.trim()};
+        final String key = unescapeLine(line.substring(0, div).trim()).trim();
+        final String value = unescapeLine(line.substring(div + 1)).trim();
+
+        if (entry == null) {
+            entry = new String[]{key, value}; 
+        } else {
+            entry[0] = key;
+            entry[1] = value;
+        }
+        
+        return entry;
+    }
+
+    /**
+     * Reads all remaining lines as a series of [key, value] pairs and stores
+     * them in the specified map.
+     *
+     * @param props the non-null map to add the read properties to
+     * @returns the map that was passed in
+     * @throws IOException if an I/O error occurs
+     */
+    public Map<String,String> readProperties(Map<String,String> props) throws IOException {
+        Objects.requireNonNull(props, "props");
+        String[] kv = readProperty(true, null);
+        while (kv != null) {
+            props.put(kv[0], kv[1]);
+            kv = readProperty(true, kv);
+        }
+        return props;
     }
 
     /**

--- a/src/ca/cgjennings/io/EscapedLineWriter.java
+++ b/src/ca/cgjennings/io/EscapedLineWriter.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.Map;
 
 /**
  * A writer that complements {@link EscapedLineReader} by automatically escaping
@@ -33,8 +34,16 @@ public class EscapedLineWriter extends BufferedWriter {
         this(new FileOutputStream(f));
     }
 
+    public EscapedLineWriter(File f, String charset) throws IOException {
+        this(new FileOutputStream(f), charset);
+    }
+
     public EscapedLineWriter(OutputStream out) throws IOException {
         super(new OutputStreamWriter(out, EscapedLineReader.RESOURCE_ENCODING));
+    }
+
+    public EscapedLineWriter(OutputStream out, String charset) throws IOException {
+        super(new OutputStreamWriter(out, charset));
     }
 
     public EscapedLineWriter(Writer out, int sz) {
@@ -111,6 +120,19 @@ public class EscapedLineWriter extends BufferedWriter {
      */
     public void writeProperty(String key, String value) throws IOException {
         writeWrapped(escapeLine(key) + " = " + escape(value));
+    }
+
+    /**
+     * Writes a collection of properties as key, value pairs with escaping
+     * and line breaking.
+     *
+     * @param props the map of properties to write
+     * @throws IOException if an I/O error occurs
+     */
+    public void writeProperties(Map<String,String> props) throws IOException {
+        for (Map.Entry<String,String> kv : props.entrySet()) {
+            writeProperty(kv.getKey(), kv.getValue());
+        }
     }
 
     private void writeUnwrapped(String line) throws IOException {

--- a/src/ca/cgjennings/io/EscapedTextCodec.java
+++ b/src/ca/cgjennings/io/EscapedTextCodec.java
@@ -7,7 +7,8 @@ package ca.cgjennings.io;
  * that a line should be concatenated with the following line.
  *
  * Valid escapeUnicode sequences consist of a backslash (\) followed by any
- * of:<br>
+ * of:
+ *
  * <pre>
  * uXXXX   insert Unicode character U+XXXX (where XXXX is a 16-bit hexadecimal number)
  * n       newline

--- a/src/ca/cgjennings/ui/textedit/tokenizers/PropertyTokenizer.java
+++ b/src/ca/cgjennings/ui/textedit/tokenizers/PropertyTokenizer.java
@@ -17,9 +17,10 @@ public class PropertyTokenizer extends Tokenizer {
     public PropertyTokenizer() {
     }
 
-    public PropertyTokenizer(boolean ignoreColon) {
-        this.ignoreColon = ignoreColon;
+    public PropertyTokenizer(boolean ignoreColons) {
+        ignoreColon = ignoreColons;
     }
+
     private boolean ignoreColon;
 
     @Override

--- a/src/ca/cgjennings/ui/textedit/tokenizers/ResourceFileTokenizer.java
+++ b/src/ca/cgjennings/ui/textedit/tokenizers/ResourceFileTokenizer.java
@@ -1,0 +1,16 @@
+package ca.cgjennings.ui.textedit.tokenizers;
+
+import gamedata.ResourceParser;
+
+/**
+ * Tokenizer for editing files that that are parsed by using a
+ * {@link ResourceParser} to read properties.
+ *
+ * @author Chris Jennings <https://cgjennings.ca/contact>
+ * @since 3.3
+ */
+public class ResourceFileTokenizer extends PropertyTokenizer {
+    public ResourceFileTokenizer() {
+        super(true);
+    }
+}

--- a/src/gamedata/ResourceParser.java
+++ b/src/gamedata/ResourceParser.java
@@ -51,6 +51,17 @@ public abstract class ResourceParser<R> implements Closeable {
      * @param gentle if {@code true}, parses in gentle mode
      */
     public ResourceParser(String resource, boolean gentle) throws IOException {
+        this(resource, null, gentle);
+    }
+
+    /**
+     * Creates a parser for the specified resource file and encoding.
+     *
+     * @param resource the location of the desired tile set resource
+     * @param charset the name of the character set to use, such as "UTF-8"
+     * @param gentle if {@code true}, parses in gentle mode
+     */
+    public ResourceParser(String resource, String charset, boolean gentle) throws IOException {
         if (resource == null) {
             throw new NullPointerException("resource");
         }
@@ -67,7 +78,7 @@ public abstract class ResourceParser<R> implements Closeable {
         this.resource = resource;
         this.gentle = gentle;
         close = true;
-        r = new EscapedLineReader(url);
+        r = charset == null ? new EscapedLineReader(url) : new EscapedLineReader(url, charset);
     }
 
     /**
@@ -78,7 +89,19 @@ public abstract class ResourceParser<R> implements Closeable {
      * @throws IOException if an I/O error occurs
      */
     public ResourceParser(InputStream in, boolean gentle) throws IOException {
-        r = new EscapedLineReader(in);
+        this(in, null, gentle);
+    }
+
+    /**
+     * Creates a parser for the specified input stream and encoding.
+     *
+     * @param in the input stream to read from
+     * @param charset the name of the character set to use, such as "UTF-8"
+     * @param gentle if {@code true}, parses in gentle mode
+     * @throws IOException if an I/O error occurs
+     */
+    public ResourceParser(InputStream in, String charset, boolean gentle) throws IOException {
+        r = charset == null ? new EscapedLineReader(in) : new EscapedLineReader(in, charset);
         this.gentle = gentle;
     }
 

--- a/src/resources/RawSettings.java
+++ b/src/resources/RawSettings.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.swing.Timer;
 
 /**


### PR DESCRIPTION
Files read/written with `EscapedLine(Reader|Writer)` or parsed with `ResourceParser` do not accept colons as a property separator, but their tokenizer/navigator implementations suggest otherwise. This provides a standard way to correct that with `ResourceFileTokenizer` and `ResourceFileNavigator`.