### PR TITLE
track recent file types separately

### DIFF
--- a/src/ca/cgjennings/apps/arkham/AbstractGameComponentEditor.java
+++ b/src/ca/cgjennings/apps/arkham/AbstractGameComponentEditor.java
@@ -449,7 +449,7 @@ public abstract class AbstractGameComponentEditor<G extends GameComponent> exten
             try {
                 final File file = getFile();
                 saveImpl(file);
-                RecentFiles.add(file);
+                RecentFiles.addRecentDocument(file);
             } catch (Exception e) {
                 ErrorDialog.displayError(string("ae-err-save"), e);
             } finally {

--- a/src/ca/cgjennings/apps/arkham/AbstractStrangeEonsEditor.java
+++ b/src/ca/cgjennings/apps/arkham/AbstractStrangeEonsEditor.java
@@ -553,7 +553,7 @@ public abstract class AbstractStrangeEonsEditor extends TAttachedEditor implemen
             try {
                 saveImpl(f);
                 setUnsavedChanges(false);
-                RecentFiles.add(f);
+                RecentFiles.addRecentDocument(f);
             } catch (Exception e) {
                 ErrorDialog.displayError(string("ae-err-save"), e);
             } finally {

--- a/src/ca/cgjennings/apps/arkham/AppFrame.java
+++ b/src/ca/cgjennings/apps/arkham/AppFrame.java
@@ -450,7 +450,7 @@ final class AppFrame extends StrangeEonsAppWindow {
                 if (f == null) {
                     f = p.getFile();
                 }
-                RecentFiles.add(f);
+                RecentFiles.addRecentProject(f);
                 createProjectView(p, true);
                 project = p;
             }
@@ -1934,7 +1934,7 @@ final class AppFrame extends StrangeEonsAppWindow {
             }
             project = proj;
             createProjectView(proj, showOpenAnimation);
-            RecentFiles.add(projectFolder);
+            RecentFiles.addRecentProject(projectFolder);
 
             // fire project event
             Object[] li = listeners.getListenerList();
@@ -2106,7 +2106,7 @@ final class AppFrame extends StrangeEonsAppWindow {
             editor.setFrameIcon(newEditorDialog.getIconForComponent(gameComponent));
         }
 
-        RecentFiles.add(f);
+        RecentFiles.addRecentDocument(f);
         editor.handleOpenRequest(gameComponent, f);
         newEditorDialog.setVisible(false);
         return editor;

--- a/src/resources/text/interface/eons-text.properties
+++ b/src/resources/text/interface/eons-text.properties
@@ -415,6 +415,7 @@ app-file = &File
   app-open = &Open...
   app-open-recent = Open Recent
     app-clear-recent = Clear Menu
+    app-clear-recent-verify = Clear the list of recent files?
   app-close = &Close
   app-close-mac = &Close
   app-save = &Save


### PR DESCRIPTION
updates recent files to separate projects and documents into separate lists; this fixes issues related to detecting their types on the fly (e.g. can't detect when the file has been deleted, app freezes if networked files are in the list)

also adds a dialog prompt to verify before clearing the recents list