### PR TITLE
Make component load times ~10x faster by not re-creating ScriptMonkey object

### DIFF
--- a/src/resources/Settings.java
+++ b/src/resources/Settings.java
@@ -118,7 +118,8 @@ public class Settings implements Serializable, Iterable<String> {
     private static final long serialVersionUID = 35461387643185L;
     private HashMap<String, String> p;
     private Settings parent;
-
+    private static ScriptMonkey scriptMonkey = null;
+    
     /**
      * Creates a new, empty {@code Settings} scope whose parent is the shared
      * global scope.
@@ -2099,15 +2100,18 @@ public class Settings implements Serializable, Iterable<String> {
                     case '{':
                         isLiteral = true;
                         valueText = valueText.substring(1, valueText.length() - (end == '}' ? 1 : 0));
-                        ScriptMonkey sm = new ScriptMonkey("style setting literal");
-                        sm.eval(
+                        if (scriptMonkey == null)
+                        {
+                            scriptMonkey = new ScriptMonkey("style setting literal");
+                            scriptMonkey.eval(
                                 "importPackage(gamedata);"
                                 + "importPackage(resources);"
                                 + "importClass(java.awt.font.TextAttribute);"
                                 + "importClass(java.awt.font.TransformAttribute);"
                                 + "importClass(java.awt.geom.AffineTransform);"
-                        );
-                        value = sm.eval(valueText);
+                            );
+                        }
+                        value = scriptMonkey.eval(valueText);
                         break;
                     case '\'':
                     case '"':


### PR DESCRIPTION
Hi. I love Strange Eons, it's great, thank you for developing it. I am working on an Arkham Horror LCG project and the load time for cards was getting quite long, ~5 seconds to load a card for editing (and on launch if lots of cards were open, minutes). 

I decided to have a go at tracking this down, not expecting to be able to do anything, but I found the cause, 90% of the time is spent re-allocating the ScriptMonkey object. I made this static and re-use it, and it seems to behave the same as before but cards load 10x faster.

I do have one problem, when I load a specific card type (locations) in my development build, the app freezes. This happens with or without the change to ScriptMonkey. I don't know why this happens, and I don't know enough about Java to try and diagnose it. Thus, the only option for me to use this fix is to have it integrated so a new build can be made that doesn't crash.

I apologise if I am breaking some taboo regarding contributing on GitHub, I usually just work on my own stuff and haven't made a pull request before :) Thanks.