### PR TITLE
Fix for #54

### DIFF
--- a/src/ca/cgjennings/apps/arkham/BusyDialog.java
+++ b/src/ca/cgjennings/apps/arkham/BusyDialog.java
@@ -26,7 +26,7 @@ import javax.swing.JFrame;
  * @author Chris Jennings <https://cgjennings.ca/contact>
  */
 @SuppressWarnings("serial")
-public final class BusyDialog extends javax.swing.JDialog {
+public final class BusyDialog {
 
     private BusyDialogImpl impl;
 

--- a/src/ca/cgjennings/apps/arkham/BusyDialogImpl.java
+++ b/src/ca/cgjennings/apps/arkham/BusyDialogImpl.java
@@ -24,7 +24,7 @@ import static resources.Language.string;
  */
 @SuppressWarnings("serial")
 final class BusyDialogImpl extends javax.swing.JDialog {
-    private final Runnable operation;
+    private Runnable operation;
     private ActionListener cancelAction;
     private final AtomicInteger maximum = new AtomicInteger(0);
     private final AtomicInteger current = new AtomicInteger(0);
@@ -89,12 +89,13 @@ final class BusyDialogImpl extends javax.swing.JDialog {
         synchronized (stack) {
             stack.push(this);
         }
-        Thread t = new Thread() {
+        Thread t = new Thread("Busy task") {
             @Override
             public void run() {
                 BusyDialogImpl.this.run();
             }
         };
+        t.setDaemon(true);
         t.start();
         setVisible(true);
     }
@@ -443,6 +444,8 @@ final class BusyDialogImpl extends javax.swing.JDialog {
                 StrangeEons.setWaitCursor(false);
                 dispose();
                 owner.setImplementation(null);
+                cancelAction = null;
+                operation = null;
             });
         }
     }

--- a/src/ca/cgjennings/apps/arkham/BusyDialogImpl.java
+++ b/src/ca/cgjennings/apps/arkham/BusyDialogImpl.java
@@ -24,7 +24,6 @@ import static resources.Language.string;
  */
 @SuppressWarnings("serial")
 final class BusyDialogImpl extends javax.swing.JDialog {
-
     private final Runnable operation;
     private ActionListener cancelAction;
     private final AtomicInteger maximum = new AtomicInteger(0);
@@ -70,7 +69,6 @@ final class BusyDialogImpl extends javax.swing.JDialog {
         this.owner = owner;
         owner.setImplementation(this);
 
-//		localizeForPlatform();
         setLocationRelativeTo(parent);
         busyLabel.setText(title);
         this.operation = operation;
@@ -444,6 +442,7 @@ final class BusyDialogImpl extends javax.swing.JDialog {
             SwingUtilities.invokeLater(() -> {
                 StrangeEons.setWaitCursor(false);
                 dispose();
+                owner.setImplementation(null);
             });
         }
     }

--- a/src/ca/cgjennings/apps/arkham/BusyDialogImpl.java
+++ b/src/ca/cgjennings/apps/arkham/BusyDialogImpl.java
@@ -433,11 +433,11 @@ final class BusyDialogImpl extends javax.swing.JDialog {
             } catch (Exception e) {
                 StrangeEons.log.log(Level.SEVERE, "BusyDialog operation threw uncaught exception", e);
             }
+        } finally {
             synchronized (stack) {
                 stack.remove(this);
                 threadMap.remove(Thread.currentThread());
-            }
-        } finally {
+            }            
             Context.exit();
             SwingUtilities.invokeLater(() -> {
                 StrangeEons.setWaitCursor(false);

--- a/src/ca/cgjennings/apps/arkham/project/DeckPacker.java
+++ b/src/ca/cgjennings/apps/arkham/project/DeckPacker.java
@@ -165,6 +165,11 @@ public class DeckPacker {
             addCard(new Card(f, index, klass, front, back));
         }
     }
+    
+    /** Removes all previously added games components. */
+    public void clear() {
+        cardList.clear();
+    }
 
     /**
      * Adds a card to the internal list of cards to include in the layout. Can
@@ -273,17 +278,21 @@ public class DeckPacker {
      * @return a new deck object containing the laid out cards
      */
     public Deck createLayout() {
-        cancelled = false;
-        Deck deck = new Deck();
-        if (addBleedMargin) {
-            final FinishStyle finishStyle = addBleedMargin ? FinishStyle.MARGIN : FinishStyle.SQUARE;
-            final double bleedMargin = addBleedMargin ? 9d : 0d;
-            deck.setFinishStyle(finishStyle);
-            deck.setBleedMarginWidth(bleedMargin);
+        try {
+            cancelled = false;
+            Deck deck = new Deck();
+            if (addBleedMargin) {
+                final FinishStyle finishStyle = addBleedMargin ? FinishStyle.MARGIN : FinishStyle.SQUARE;
+                final double bleedMargin = addBleedMargin ? 9d : 0d;
+                deck.setFinishStyle(finishStyle);
+                deck.setBleedMarginWidth(bleedMargin);
+            }
+            deck.setPaperProperties(paper);
+            layout(deck);
+            return deck;
+        } finally {
+            areas = null;
         }
-        deck.setPaperProperties(paper);
-        layout(deck);
-        return deck;
     }
 
     /**
@@ -294,11 +303,15 @@ public class DeckPacker {
      * @param deckEditor the deck that will contain the laid out cards
      */
     public void createLayout(DeckEditor deckEditor) {
-        cancelled = false;
-        usingEditor = deckEditor;
-        Deck deck = deckEditor.getDeck();
-        deck.setPaperProperties(paper);
-        layout(deck);
+        try {
+            cancelled = false;
+            usingEditor = deckEditor;
+            Deck deck = deckEditor.getDeck();
+            deck.setPaperProperties(paper);
+            layout(deck);
+        } finally {
+            areas = null;
+        }
     }
     private DeckEditor usingEditor;
 

--- a/src/ca/cgjennings/apps/arkham/project/MakeDeck.java
+++ b/src/ca/cgjennings/apps/arkham/project/MakeDeck.java
@@ -34,12 +34,14 @@ public class MakeDeck extends TaskAction {
 
     @Override
     public boolean perform(final Project project, final Task task, final Member member) {
-        final MakeDeckDialog d = new MakeDeckDialog(StrangeEons.getWindow(), true);
+        MakeDeckDialog d = new MakeDeckDialog(StrangeEons.getWindow(), true);
         project.getView().moveToLocusOfAttention(d);
         final DeckPacker packer = d.showDialog();
         if (packer == null) {
             return false;
         }
+        final String deckFileName = d.getSelectedFileName();
+        d = null; // allow GC during build
 
         new BusyDialog(StrangeEons.getWindow(), string("pa-makedeck-busy"), () -> {
             try {
@@ -50,7 +52,7 @@ public class MakeDeck extends TaskAction {
                     copies = new CopiesList();
                     StrangeEons.log.log(Level.WARNING, "unable to read copies list, using card count of 1 for all files", e);
                 }
-                File deckFile = new File(task.getFile(), d.getSelectedFileName());
+                File deckFile = new File(task.getFile(), deckFileName);
                 List<Member> list = ProjectUtilities.listMatchingMembers(task, true, "eon");
                 for (Member m : list) {
                     if (m == null) {
@@ -75,6 +77,8 @@ public class MakeDeck extends TaskAction {
                 }
             } catch (CancellationException cancel) {
                 // user cancelled the operation
+            } finally {
+                packer.clear();
             }
         }, (ActionEvent e) -> {
             packer.cancel();


### PR DESCRIPTION
Likely fix for #54. In profiling deck packing, there were indeed objects that appeared to be leaking, yet they could not be traced to a GC root. That is, they should be available for garbage collection, yet they were not collected. This PR explicitly nulls some key objects, and profiling indicates that the previously leaked objects are now being GC'd as expected.