### PR TITLE
Fix fatal error dialog

### DIFF
--- a/src/main/java/ca/cgjennings/apps/arkham/StrangeEons.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/StrangeEons.java
@@ -2562,6 +2562,7 @@ public final class StrangeEons {
         } else {
             log.info("starting background initialization");
             backgroundInitThread = new Thread(backgroundInit, "Background init thread");
+            backgroundInitThread.setDaemon(true);
             backgroundInitThread.start();
         }
     }

--- a/src/main/java/ca/cgjennings/apps/arkham/dialog/ErrorDialog.form
+++ b/src/main/java/ca/cgjennings/apps/arkham/dialog/ErrorDialog.form
@@ -113,8 +113,8 @@
     </Component>
     <Component class="javax.swing.JButton" name="reportBtn">
       <Properties>
-        <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
-          <Image iconType="3" name="/resources/icons/ui/bug-report.png"/>
+        <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="ResourceKit.getIcon(&quot;bug-report&quot;)" type="code"/>
         </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="resources/text/interface/eons-text.properties" key="app-report-bug" replaceFormat="string(&quot;{key}&quot;)"/>

--- a/src/main/java/ca/cgjennings/apps/arkham/plugins/BundleInstaller.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/plugins/BundleInstaller.java
@@ -1159,13 +1159,13 @@ public class BundleInstaller {
 
     private static void init() {
         if (!JarLoader.isSupported()) {
-            throw new AssertionError(
-                    "unable to load plugins, try adding -javaagent:<path to strange-eons.jar> to the command line"
+            ErrorDialog.displayFatalError(
+                    "Unable to link to plug-in bundles; add <tt>-javaagent:strange-eons.jar</tt> to the command line",
+                    null
             );
         }
 
-        StrangeEons.log.info("loading dynamic bundles via " + JarLoader.getStrategy());
-
+        StrangeEons.log.log(Level.INFO, "loading dynamic bundles via {0}", JarLoader.getStrategy());
         deprecatedBundles = null;
         String ignoreValue = Settings.getShared().get("deprecated-bundles");
         if (ignoreValue != null) {

--- a/src/main/resources/resources/icons/map.properties
+++ b/src/main/resources/resources/icons/map.properties
@@ -130,7 +130,7 @@ dev-manual=gly:F05DA,v
 translation-manual=gly:F05DA,w
 help-java-api=gly:F109B,b
 help-js-api=gly:F109B,y
-bug-report=gly:F0182;F00E4@-8,0,-2
+bug-report=gly:F0182@+0,0,2;F00E4@-8
 
 # Context bar
 separator=gly:F050C,b


### PR DESCRIPTION
The error dialog directly loaded an old (now gone) icon resource, causing it to throw NPE on construction.