### PR TITLE
Fix: possible NPE on rename

### DIFF
--- a/src/main/java/ca/cgjennings/apps/arkham/project/Rename.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/project/Rename.java
@@ -84,6 +84,7 @@ public class Rename extends TaskAction {
             StrangeEons.getWindow().closeProject();
         }
 
+        final Member parent = member instanceof Project ? null : member.getParent();
         File oldFile = member.getFile();
         boolean isDir = oldFile.isDirectory();
 
@@ -141,8 +142,9 @@ public class Rename extends TaskAction {
                 }
             }
 
-            if (!(member instanceof Project)) {
-                member.getParent().synchronize();
+            // refresh view with updated name immediately
+            if (parent != null) {
+                parent.synchronize();
             }
         } catch (IOException ioe) {
             // FAILED TO RENAME


### PR DESCRIPTION
Renaming a project folder may produce a (harmless) NPE if the members are synched before the rename completes. The renamer also manually synchs the parent folder (so the change appears in the view immediately), but the old member may no longer have a parent.