### PR TITLE
fix: addCustomComponent with new themes

### DIFF
--- a/src/main/java/ca/cgjennings/apps/arkham/AppFrame.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/AppFrame.java
@@ -614,7 +614,7 @@ final class AppFrame extends StrangeEonsAppWindow {
             topToolBar = createToolBar();
         }
         topToolBar.add(comp, index);
-        topToolBar.validate();
+        getRootPane().revalidate();
     }
 
     /**
@@ -626,12 +626,8 @@ final class AppFrame extends StrangeEonsAppWindow {
      */
     @Override
     public Component addCustomComponentSeparator() {
-        if (topToolBar == null) {
-            topToolBar = createToolBar();
-        }
-        JComponent sep = new JToolBar.Separator();
-        topToolBar.add(sep);
-        topToolBar.validate();
+        final Component sep = new JToolBar.Separator();
+        addCustomComponent(sep, -1);
         return sep;
     }
 
@@ -682,7 +678,7 @@ final class AppFrame extends StrangeEonsAppWindow {
         if (topToolBar.getComponentCount() == 0) {
             topToolBar.getParent().remove(topToolBar);
             topToolBar = null;
-            validate();
+            getRootPane().revalidate();
         }
     }
 

--- a/src/main/java/register.java
+++ b/src/main/java/register.java
@@ -1,7 +1,6 @@
 
 import ca.cgjennings.apps.CommandLineParser;
 import ca.cgjennings.graphics.ImageUtilities;
-import ca.cgjennings.io.StreamPump;
 import ca.cgjennings.platform.Shell;
 import ca.cgjennings.platform.Shell.Result;
 import java.awt.RenderingHints;
@@ -11,12 +10,10 @@ import java.io.Console;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URL;
-import java.util.List;
 import javax.imageio.ImageIO;
 
 /**


### PR DESCRIPTION
With new Themes, components added with addCustomComponent don't appear unless the window is forced to revalidate (e.g. resize).