### PR TITLE
fix member name unreadable when file is dirty

### DIFF
--- a/src/main/java/ca/cgjennings/apps/arkham/project/Member.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/project/Member.java
@@ -277,12 +277,6 @@ public class Member implements IconProvider, Iterable<Member>, Comparable<Member
      */
     public boolean hasChildren() {
         if (children == null) {
-            // speculate that there are files
-//				File[] files = file.listFiles( FILE_FILTER );
-//				if( files != null ) {
-//					return files.length > 0;
-//				}
-
             return file.isDirectory();
         } else {
             return getChildCount() > 0;

--- a/src/main/java/ca/cgjennings/apps/arkham/project/ProjectView.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/project/ProjectView.java
@@ -22,6 +22,7 @@ import ca.cgjennings.ui.StyleUtilities;
 import ca.cgjennings.ui.TreeLabelExposer;
 import ca.cgjennings.ui.anim.AnimationUtilities;
 import ca.cgjennings.ui.text.ErrorSquigglePainter;
+import ca.cgjennings.ui.theme.Palette;
 import ca.cgjennings.ui.theme.Theme;
 import java.awt.Color;
 import java.awt.Component;
@@ -1608,7 +1609,7 @@ public final class ProjectView extends javax.swing.JPanel {
             cutAttributes.put(TextAttribute.STRIKETHROUGH, TextAttribute.STRIKETHROUGH_ON);
             cutAttributes.put(TextAttribute.FOREGROUND, Color.GRAY);
         }
-        private final Map<TextAttribute, ? extends Object> unsavedAttributes = Collections.singletonMap(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD);
+        private final Map<TextAttribute, ? extends Object> unsavedAttributes = Collections.singletonMap(TextAttribute.FOREGROUND, Palette.get.foreground.translucent.yellow);
         private Icon blank;
     }
 


### PR DESCRIPTION
project member name becomes unreadable (e.g., `README` -> `READ...`) when the file is open and modified. instead of bolding the member font, we turn it palette yellow. the tab icons can be updated to match.