### PR TITLE
fix comma and other chars not allowed in portraits

### DIFF
--- a/src/main/java/ca/cgjennings/ui/FilteredDocument.java
+++ b/src/main/java/ca/cgjennings/ui/FilteredDocument.java
@@ -155,19 +155,19 @@ public class FilteredDocument extends PlainDocument {
      * @return a file name filtering document
      */
     public static final PlainDocument createFileNameDocument() {
-        return new FilteredDocument("?[]/\\=+<>:;\",*|^~");
+        return new FilteredDocument("<>\\\"|?*:/\\");
     }
 
     /**
      * Returns a new document that filters out characters that are illegal in
-     * Windows, *NIX file paths. This is identical to the filter created with
-     * {@link #createFileNameDocument()}, but it does not filter path characters
-     * (/, \, and :).
+     * Windows, *NIX file paths.
+     * This is identical to the filter created with {@link #createFileNameDocument()},
+     * but it does not filter path characters.
      *
      * @return a file path filtering document
      */
     public static final PlainDocument createFilePathDocument() {
-        return new FilteredDocument("?[]=+<>;\",*|^~");
+        return new FilteredDocument("<>\"|?*");
     }
 
     /**


### PR DESCRIPTION
DnD or selecting paths containing any of [,=+;^~] failed because they were filtered out of the file name field; affects other uses of JFileField and friends as well.