### PR TITLE
workaround ToolWindow drag on multi HDPI screens

### DIFF
--- a/src/main/java/ca/cgjennings/apps/arkham/ViewQuality.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/ViewQuality.java
@@ -105,7 +105,7 @@ public enum ViewQuality {
      * @param sheet the sheet to determine the upsample factor for
      * @return the suggested upsample factor for the sheet at this quality level
      */
-    public double getSheetViewerUpsample(Sheet sheet) {
+    public double getSheetViewerUpsample(Sheet<?> sheet) {
         return Math.max(upsample, sheet.getSuggestedUpsampleFactor());
     }
 


### PR DESCRIPTION
Works around a bug that affects ToolWindows (such as the console) when dragging them to a second high DPI display. See diff for explanation.

This workaround can be disabled by setting the preference key `window-location-bug-workaround` to `false`.