### PR TITLE
fix code folding setting ignored

### DIFF
--- a/src/main/java/ca/cgjennings/ui/textedit/CodeEditorBase.java
+++ b/src/main/java/ca/cgjennings/ui/textedit/CodeEditorBase.java
@@ -69,17 +69,16 @@ public class CodeEditorBase extends JPanel {
             // we can ignore and keep default font
         }
 
-        setCodeType(null);
-
         scroll = new RTextScrollPane(textArea);
         scroll.setIconRowHeaderEnabled(true);
+        // scroll.setFoldIndicatorEnabled(true);
         add(scroll, BorderLayout.CENTER);
-
+        
         errorStrip = new ErrorStrip(textArea);
         add(errorStrip, BorderLayout.LINE_END);
-
-        addKeyBindings();
         
+        addKeyBindings();
+        setCodeType(null);
         ready = true;
     }
 
@@ -1072,11 +1071,15 @@ public class CodeEditorBase extends JPanel {
      * @see #isCodeFoldingEnabled() 
      */
     public void setCodeFoldingEnabled(boolean enable) {
-        if (enable == isCodeFoldingEnabled()) return;
-        
+        if (enable == codeFoldingEnabled) return;
+        codeFoldingEnabled = enable;
+        // force reset since parser may have been cleared
+        textArea.setCodeFoldingEnabled(!enable);
         textArea.setCodeFoldingEnabled(enable);
-        scroll.setFoldIndicatorEnabled(enable);
     }
+
+    // the text area's code folding state may not always match the intended state
+    private boolean codeFoldingEnabled = true;
     
     /**
      * Returns whether or not code folding is enabled for supported code types.
@@ -1085,7 +1088,7 @@ public class CodeEditorBase extends JPanel {
      * @see #setCodeFoldingEnabled(boolean) 
      */    
     public boolean isCodeFoldingEnabled() {
-        return textArea.isCodeFoldingEnabled();
+        return codeFoldingEnabled;
     }
 
     /**

--- a/src/main/java/ca/cgjennings/ui/textedit/DefaultCodeSupport.java
+++ b/src/main/java/ca/cgjennings/ui/textedit/DefaultCodeSupport.java
@@ -4,6 +4,8 @@ import java.io.File;
 import org.fife.ui.rsyntaxtextarea.AbstractTokenMakerFactory;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rsyntaxtextarea.TokenMakerFactory;
+import org.fife.ui.rsyntaxtextarea.folding.FoldParser;
+import org.fife.ui.rsyntaxtextarea.folding.FoldParserManager;
 
 /**
  * Default code support; adds basic syntax highlighting based on the editor's
@@ -20,19 +22,28 @@ public class DefaultCodeSupport implements CodeSupport {
         AbstractTokenMakerFactory factory = (AbstractTokenMakerFactory) TokenMakerFactory.getDefaultInstance();
         factory.putMapping(SYNTAX_SE_JAVASCRIPT, SEJavaScriptTokenMaker.class.getName());
         factory.putMapping(SYNTAX_RESOURCE_FILE, ResourceFileTokenMaker.class.getName());
+
+        // register fold parsers
+        FoldParserManager fpm = FoldParserManager.get();
+        FoldParser jsLike = fpm.getFoldParser(SyntaxConstants.SYNTAX_STYLE_JAVASCRIPT);
+        fpm.addFoldParserMapping(SYNTAX_SE_JAVASCRIPT, jsLike);
     }
 
     @Override
     public void install(CodeEditorBase editor) {
         final SyntaxTextArea ta = editor.getTextArea();
+        ta.clearParsers();
 
         String id = languageIdFor(editor);
         if (id == null) {
             id = SyntaxConstants.SYNTAX_STYLE_NONE;
         }
 
-        ta.clearParsers();
         ta.setSyntaxEditingStyle(id);
+
+        boolean enableFolding = editor.isCodeFoldingEnabled();
+        ta.setCodeFoldingEnabled(!enableFolding);
+        ta.setCodeFoldingEnabled(enableFolding);
     }
 
     @Override


### PR DESCRIPTION
changing code type clears parsers, which removes any code folding; this fix force toggles code folding to its desired state and adds folding for script files