### PR TITLE
Fix #148: make "All Games" selectable in New Component game filter

### DIFF
--- a/src/main/java/ca/cgjennings/apps/arkham/NewEditorDialog.java
+++ b/src/main/java/ca/cgjennings/apps/arkham/NewEditorDialog.java
@@ -535,9 +535,9 @@ public final class NewEditorDialog extends javax.swing.JDialog {
             final Settings s = Settings.getUser();
             s.storeWindowSettings("neweditor", this);
             Object filter = gameFilter.getSelectedItem();
-            if (filter != null) {
-                s.set(FILTER_KEY, filter.toString());
-            }
+            // persist the filter — including an empty/cleared value, so users
+            // can reset the filter across sessions (issue #148)
+            s.set(FILTER_KEY, filter == null ? "" : filter.toString());
         }
         super.dispose();
     }

--- a/src/main/java/ca/cgjennings/ui/JGameFilterField.java
+++ b/src/main/java/ca/cgjennings/ui/JGameFilterField.java
@@ -89,7 +89,7 @@ public class JGameFilterField extends JComboBox<Game> {
                     return this;
                 }
             });
-            setModel(new DefaultComboBoxModel<>(Game.getGames(false)));
+            setModel(new DefaultComboBoxModel<>(Game.getGames(true)));
             setSelectedItem(Settings.getUser().get(KEY, ""));
 
             // add listeners after default value set so that events are not fired during init
@@ -154,9 +154,14 @@ public class JGameFilterField extends JComboBox<Game> {
         }
         DefaultComboBoxModel<Game> m = (DefaultComboBoxModel<Game>) getModel();
         for (int i = 0; i < m.getSize(); ++i) {
-            String t = ((Game) m.getElementAt(i)).getUIName().trim();
+            Game g = m.getElementAt(i);
+            String t = g.getUIName().trim();
             if (t.equalsIgnoreCase(v)) {
-                return m.getElementAt(i);
+                // treat the "All Games" pseudo-entry as an empty filter
+                if (Game.ALL_GAMES_CODE.equals(g.getCode())) {
+                    return null;
+                }
+                return g;
             }
         }
         return v;


### PR DESCRIPTION
The game filter dropdown excluded the special All Games entry; once a user selected a specific game, there was no discoverable way to restore the full list; users had to know to manually clear the combobox text. Additionally, a null filter value in dispose() was never written back, so even clearing the text in-session didn't persist across launches.

- JGameFilterField: include the All Games entry in the dropdown model and map it to a null filter value in getFilterValue().
- NewEditorDialog.dispose(): always persist the current filter value, including empty/cleared states.